### PR TITLE
cmd/atlas: add dirFormat flag to migrate apply

### DIFF
--- a/cmd/atlas/internal/cmdapi/migrate.go
+++ b/cmd/atlas/internal/cmdapi/migrate.go
@@ -51,6 +51,7 @@ func migrateCmd() *cobra.Command {
 type migrateApplyFlags struct {
 	url             string
 	dirURL          string
+	dirFormat       string
 	revisionSchema  string
 	dryRun          bool
 	logFormat       string
@@ -144,6 +145,7 @@ If run with the "--dry-run" flag, atlas will not execute any SQL.`,
 	cmd.Flags().SortFlags = false
 	addFlagURL(cmd.Flags(), &flags.url)
 	addFlagDirURL(cmd.Flags(), &flags.dirURL)
+	addFlagDirFormat(cmd.Flags(), &flags.dirFormat)
 	addFlagLog(cmd.Flags(), &flags.logFormat)
 	addFlagFormat(cmd.Flags(), &flags.logFormat)
 	addFlagRevisionSchema(cmd.Flags(), &flags.revisionSchema)

--- a/cmd/atlas/internal/cmdapi/migrate_oss.go
+++ b/cmd/atlas/internal/cmdapi/migrate_oss.go
@@ -35,6 +35,9 @@ func migrateApplyRun(cmd *cobra.Command, args []string, flags migrateApplyFlags,
 			return fmt.Errorf("cannot apply '%d' migration files", count)
 		}
 	}
+	if err := dirFormatBC(flags.dirFormat, &flags.dirURL); err != nil {
+		return err
+	}
 	dirURL, err := url.Parse(flags.dirURL)
 	if err != nil {
 		return fmt.Errorf("parse dir-url: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying migration directory format via a new --dir-format flag in the migrate apply command.
  * Introduced pre-validation of the directory configuration, providing earlier, clearer errors when format and URL settings are incompatible.

* **Tests**
  * Added test suite validating golang-migrate directory format handling, including use via flag, atlas.hcl configuration, and query-parameter formats, ensuring only intended “up” migrations run in dry-run scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->